### PR TITLE
go-like install way

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Use Oplus official api to query OPlus,OPPO and Realme Mobile 's OS version update.
 
+## Install
+
+```shell
+$ go install github.com/Houvven/OplusUpdater@latest
+```
+
 ## How to use?
 ```shell
 $ oplus-updater -h                                              

--- a/api/request.go
+++ b/api/request.go
@@ -10,7 +10,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"updater/config"
+
+	"github.com/Houvven/OplusUpdater/config"
 
 	"github.com/deatil/go-cryptobin/cryptobin/crypto"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"updater/api"
-	"updater/config"
-	"updater/util"
+
+	"github.com/Houvven/OplusUpdater/api"
+	"github.com/Houvven/OplusUpdater/config"
+	"github.com/Houvven/OplusUpdater/util"
 
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module updater
+module github.com/Houvven/OplusUpdater
 
 go 1.22
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"updater/cmd"
+	"github.com/Houvven/OplusUpdater/cmd"
 )
 
 func main() {


### PR DESCRIPTION
It will be more convenient for many people to install Go packages using the Go-like way. This PR implements that. I also fixed and sorted the imports to make this approach work.